### PR TITLE
fix: exclude elm-stuff from file search

### DIFF
--- a/packages/file-search-worker/src/parts/GetFileSearchRipGrepArgs/GetFileSearchRipGrepArgs.ts
+++ b/packages/file-search-worker/src/parts/GetFileSearchRipGrepArgs/GetFileSearchRipGrepArgs.ts
@@ -1,4 +1,4 @@
 export const getFileSearchRipGrepArgs = (): readonly string[] => {
-  const ripGrepArgs = ['--files', '--sort-files', '--hidden', '--glob', '!.git']
+  const ripGrepArgs = ['--files', '--sort-files', '--hidden', '--glob', '!.git', '--glob', '!elm-stuff']
   return ripGrepArgs
 }

--- a/packages/file-search-worker/test/GetFIleSearchRipGrepArgs.test.ts
+++ b/packages/file-search-worker/test/GetFIleSearchRipGrepArgs.test.ts
@@ -3,5 +3,5 @@ import * as GetFileSearchRipGrepArgs from '../src/parts/GetFileSearchRipGrepArgs
 
 test('getFileSearchRipGrepArgs', () => {
   const args = GetFileSearchRipGrepArgs.getFileSearchRipGrepArgs()
-  expect(args).toEqual(['--files', '--sort-files', '--hidden', '--glob', '!.git'])
+  expect(args).toEqual(['--files', '--sort-files', '--hidden', '--glob', '!.git', '--glob', '!elm-stuff'])
 })

--- a/packages/file-search-worker/test/SearchFileWithRipGrep.test.ts
+++ b/packages/file-search-worker/test/SearchFileWithRipGrep.test.ts
@@ -15,7 +15,7 @@ test('searches files without prepare', async () => {
       'SearchFile.searchFile',
       {
         limit: 9_999_999,
-        ripGrepArgs: ['--files', '--sort-files', '--hidden', '--glob', '!.git'],
+        ripGrepArgs: ['--files', '--sort-files', '--hidden', '--glob', '!.git', '--glob', '!elm-stuff'],
         searchPath: '/test',
       },
     ],
@@ -35,7 +35,7 @@ test('searches files with prepare', async () => {
       'SearchFile.searchFile',
       {
         limit: 9_999_999,
-        ripGrepArgs: ['--files', '--sort-files', '--hidden', '--glob', '!.git'],
+        ripGrepArgs: ['--files', '--sort-files', '--hidden', '--glob', '!.git', '--glob', '!elm-stuff'],
         searchPath: '/test',
       },
     ],
@@ -55,7 +55,7 @@ test('handles empty result', async () => {
       'SearchFile.searchFile',
       {
         limit: 9_999_999,
-        ripGrepArgs: ['--files', '--sort-files', '--hidden', '--glob', '!.git'],
+        ripGrepArgs: ['--files', '--sort-files', '--hidden', '--glob', '!.git', '--glob', '!elm-stuff'],
         searchPath: '/test',
       },
     ],
@@ -76,7 +76,7 @@ test('handles error from search process', async () => {
       'SearchFile.searchFile',
       {
         limit: 9_999_999,
-        ripGrepArgs: ['--files', '--sort-files', '--hidden', '--glob', '!.git'],
+        ripGrepArgs: ['--files', '--sort-files', '--hidden', '--glob', '!.git', '--glob', '!elm-stuff'],
         searchPath: '/test',
       },
     ],


### PR DESCRIPTION
Exclude Elm's generated elm-stuff directory from the default file-search results used by Quick Pick.